### PR TITLE
[GEN-1471] feat: delete entity modal

### DIFF
--- a/frontend/webapp/app/main/page.tsx
+++ b/frontend/webapp/app/main/page.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { OverviewDataFlowContainer } from '@/containers';
 import React from 'react';
+import { OverviewDataFlowContainer } from '@/containers';
 
 export default function MainPage() {
   return (

--- a/frontend/webapp/components/index.ts
+++ b/frontend/webapp/components/index.ts
@@ -6,3 +6,4 @@ export * from './notification/notification-manager';
 export * from './notification/notification-list';
 export * from './destinations';
 export * from './main';
+export * from './modals';

--- a/frontend/webapp/components/modals/delete-entity-modal/index.tsx
+++ b/frontend/webapp/components/modals/delete-entity-modal/index.tsx
@@ -1,0 +1,73 @@
+import React, { useCallback } from 'react';
+import { Button, Modal, Text } from '@/reuseable-components';
+import styled from 'styled-components';
+
+interface AddActionModalProps {
+  title: string;
+  description: string;
+  isModalOpen: boolean;
+  handleDelete: () => void;
+  handleCloseModal: () => void;
+}
+
+export const DeleteEntityModal: React.FC<AddActionModalProps> = ({
+  isModalOpen,
+  handleCloseModal,
+  title = '',
+  handleDelete,
+  description = '',
+}) => {
+  const handleClose = useCallback(() => {
+    handleCloseModal();
+  }, [handleCloseModal]);
+
+  return (
+    <Modal isOpen={isModalOpen} onClose={handleClose}>
+      <DeleteEntityModalContainer>
+        <ModalTitle>Delete {title}</ModalTitle>
+        <ModalContent>
+          <ModalDescription>{description}</ModalDescription>
+        </ModalContent>
+        <ModalFooter>
+          <FooterButton variant="danger" onClick={handleDelete}>
+            Delete
+          </FooterButton>
+          <FooterButton variant={'secondary'} onClick={handleClose}>
+            Cancel
+          </FooterButton>
+        </ModalFooter>
+      </DeleteEntityModalContainer>
+    </Modal>
+  );
+};
+
+const ModalTitle = styled(Text)`
+  font-size: 20px;
+  line-height: 28px;
+`;
+
+const ModalDescription = styled(Text)`
+  color: ${({ theme }) => theme.text.grey};
+  width: 416px;
+  font-style: normal;
+  font-weight: 300;
+  line-height: 24px;
+`;
+
+const ModalContent = styled.div`
+  padding: 12px 0px 32px 0;
+`;
+
+const ModalFooter = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+`;
+
+const FooterButton = styled(Button)`
+  width: 224px;
+`;
+
+const DeleteEntityModalContainer = styled.div`
+  padding: 24px 32px;
+`;

--- a/frontend/webapp/components/modals/index.tsx
+++ b/frontend/webapp/components/modals/index.tsx
@@ -1,0 +1,1 @@
+export * from './delete-entity-modal';

--- a/frontend/webapp/containers/main/overview/overview-data-flow/index.tsx
+++ b/frontend/webapp/containers/main/overview/overview-data-flow/index.tsx
@@ -1,11 +1,15 @@
 'use client';
+import dynamic from 'next/dynamic';
 import styled from 'styled-components';
 import { useDrawerStore } from '@/store';
-import { OverviewDrawer } from '../overview-drawer';
 import React, { useMemo, useRef, useEffect, useState } from 'react';
 import { OverviewActionMenuContainer } from '../overview-actions-menu';
 import { buildNodesAndEdges, NodeBaseDataFlow } from '@/reuseable-components';
 import { useActualDestination, useActualSources, useGetActions } from '@/hooks';
+
+const OverviewDrawer = dynamic(() => import('../overview-drawer'), {
+  ssr: false,
+});
 
 export const OverviewDataFlowWrapper = styled.div`
   width: calc(100% - 64px);

--- a/frontend/webapp/containers/main/overview/overview-drawer/drawer-footer/index.tsx
+++ b/frontend/webapp/containers/main/overview/overview-drawer/drawer-footer/index.tsx
@@ -91,7 +91,5 @@ const ButtonText = styled(Text)<{
   font-size: 14px;
   font-weight: 600;
   font-family: ${({ theme }) => theme.font_family.secondary};
-  text-decoration-line: underline;
-  text-transform: uppercase;
   width: fit-content;
 `;

--- a/frontend/webapp/containers/main/overview/overview-drawer/drawer-header/index.tsx
+++ b/frontend/webapp/containers/main/overview/overview-drawer/drawer-header/index.tsx
@@ -62,12 +62,13 @@ const ButtonText = styled(Text)`
 interface DrawerHeaderProps {
   title: string;
   imageUri: string;
+  onClose: () => void;
   isEditing: boolean;
   setIsEditing: (isEditing: boolean) => void;
 }
 
 const DrawerHeader = forwardRef<HTMLInputElement, DrawerHeaderProps>(
-  ({ title, imageUri, isEditing, setIsEditing }, ref) => {
+  ({ title, imageUri, isEditing, setIsEditing, onClose }, ref) => {
     const [inputValue, setInputValue] = useState(title);
 
     useEffect(() => {
@@ -104,7 +105,7 @@ const DrawerHeader = forwardRef<HTMLInputElement, DrawerHeaderProps>(
               <ButtonText>Edit</ButtonText>
             </EditButton>
           )}
-          <CloseButton variant="secondary" onClick={() => setIsEditing(false)}>
+          <CloseButton variant="secondary" onClick={onClose}>
             <Image
               src="/icons/common/x.svg"
               alt="Close"

--- a/frontend/webapp/containers/main/overview/overview-drawer/index.tsx
+++ b/frontend/webapp/containers/main/overview/overview-drawer/index.tsx
@@ -109,45 +109,53 @@ const OverviewDrawer = () => {
   const SpecificComponent = componentMap[selectedItem.type];
 
   return SpecificComponent ? (
-    <Drawer isOpen onClose={handleClose} width={DRAWER_WIDTH}>
-      <DrawerContent>
-        <DrawerHeader
-          ref={titleRef}
-          title={title}
-          imageUri={
-            selectedItem?.item
-              ? getMainContainerLanguageLogo(
-                  selectedItem.item as K8sActualSource
-                )
-              : ''
-          }
-          {...{ isEditing, setIsEditing }}
-        />
-        <ContentArea>
-          <SpecificComponent />
-        </ContentArea>
-        {isEditing && (
-          <>
-            <DrawerFooter
-              onSave={handleSave}
-              onCancel={handleCancel}
-              onDelete={() => setIsDeleteModalOpen(true)}
-            />
-            <DeleteEntityModal
-              title={title}
-              isModalOpen={isDeleteModalOpen}
-              handleDelete={handleDelete}
-              handleCloseModal={handleCloseDeleteModal}
-              description="Are you sure you want to delete this source?"
-            />
-          </>
-        )}
-      </DrawerContent>
-    </Drawer>
+    <>
+      <Drawer
+        isOpen
+        onClose={handleClose}
+        width={DRAWER_WIDTH}
+        closeOnEscape={!isDeleteModalOpen}
+      >
+        <DrawerContent>
+          <DrawerHeader
+            ref={titleRef}
+            title={title}
+            onClose={isEditing ? handleCancel : handleClose}
+            imageUri={
+              selectedItem?.item
+                ? getMainContainerLanguageLogo(
+                    selectedItem.item as K8sActualSource
+                  )
+                : ''
+            }
+            {...{ isEditing, setIsEditing }}
+          />
+          <ContentArea>
+            <SpecificComponent />
+          </ContentArea>
+          {isEditing && (
+            <>
+              <DrawerFooter
+                onSave={handleSave}
+                onCancel={handleCancel}
+                onDelete={() => setIsDeleteModalOpen(true)}
+              />
+            </>
+          )}
+        </DrawerContent>
+      </Drawer>
+      <DeleteEntityModal
+        title={title}
+        isModalOpen={isDeleteModalOpen}
+        handleDelete={handleDelete}
+        handleCloseModal={handleCloseDeleteModal}
+        description="Are you sure you want to delete this source?"
+      />
+    </>
   ) : null;
 };
 
-export { OverviewDrawer };
+export default OverviewDrawer;
 
 const DrawerContent = styled.div`
   display: flex;

--- a/frontend/webapp/containers/main/overview/overview-drawer/index.tsx
+++ b/frontend/webapp/containers/main/overview/overview-drawer/index.tsx
@@ -6,6 +6,7 @@ import DrawerHeader from './drawer-header';
 import DrawerFooter from './drawer-footer';
 import { SourceDrawer } from '../../sources';
 import { Drawer } from '@/reuseable-components';
+import { DeleteEntityModal } from '@/components';
 import { getMainContainerLanguageLogo } from '@/utils/constants/programming-languages';
 import { K8sActualSource, PatchSourceRequestInput, WorkloadId } from '@/types';
 
@@ -24,6 +25,7 @@ const OverviewDrawer = () => {
   );
   const [isEditing, setIsEditing] = useState(false);
   const [title, setTitle] = useState(selectedItem?.item?.name || '');
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const { updateActualSource, deleteSourcesForNamespace } = useActualSources();
 
@@ -95,6 +97,11 @@ const OverviewDrawer = () => {
   const handleClose = () => {
     setIsEditing(false);
     setDrawerItem(null);
+    setIsDeleteModalOpen(false);
+  };
+
+  const handleCloseDeleteModal = () => {
+    setIsDeleteModalOpen(false);
   };
 
   if (!selectedItem) return null;
@@ -120,11 +127,20 @@ const OverviewDrawer = () => {
           <SpecificComponent />
         </ContentArea>
         {isEditing && (
-          <DrawerFooter
-            onSave={handleSave}
-            onCancel={handleCancel}
-            onDelete={handleDelete}
-          />
+          <>
+            <DrawerFooter
+              onSave={handleSave}
+              onCancel={handleCancel}
+              onDelete={() => setIsDeleteModalOpen(true)}
+            />
+            <DeleteEntityModal
+              title={title}
+              isModalOpen={isDeleteModalOpen}
+              handleDelete={handleDelete}
+              handleCloseModal={handleCloseDeleteModal}
+              description="Are you sure you want to delete this source?"
+            />
+          </>
         )}
       </DrawerContent>
     </Drawer>

--- a/frontend/webapp/reuseable-components/button/index.tsx
+++ b/frontend/webapp/reuseable-components/button/index.tsx
@@ -2,7 +2,7 @@ import React, { ButtonHTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'primary' | 'secondary' | 'tertiary';
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'danger';
   isDisabled?: boolean;
 }
 
@@ -23,7 +23,7 @@ const variantStyles = {
   secondary: css`
     background: rgba(249, 249, 249, 0);
     border: 1px solid rgba(82, 82, 82, 1);
-
+    color: ${({ theme }) => theme.colors.secondary};
     &:hover {
       border: 1px solid rgba(249, 249, 249, 0.32);
       background: rgba(249, 249, 249, 0.04);
@@ -49,6 +49,20 @@ const variantStyles = {
       background: rgba(249, 249, 249, 0);
     }
   `,
+  danger: css`
+    border-color: transparent;
+    background: ${({ theme }) => theme.colors.danger};
+    &:hover {
+      background: ${({ theme }) => theme.colors.danger};
+      opacity: 0.9;
+    }
+    &:active {
+      background: ${({ theme }) => theme.colors.danger};
+    }
+    &:focus {
+      background: ${({ theme }) => theme.colors.danger};
+    }
+  `,
 };
 
 const StyledButton = styled.button<ButtonProps>`
@@ -59,6 +73,10 @@ const StyledButton = styled.button<ButtonProps>`
   justify-content: center;
   align-items: center;
   padding: 0 12px;
+  font-family: ${({ theme }) => theme.font_family.secondary};
+  text-transform: uppercase;
+  text-decoration: underline;
+  font-weight: 600;
   ${({ variant }) => variant && variantStyles[variant]}
   ${({ isDisabled }) =>
     isDisabled &&
@@ -72,7 +90,7 @@ const StyledButton = styled.button<ButtonProps>`
 `;
 
 const ButtonContainer = styled.div<{
-  variant?: 'primary' | 'secondary' | 'tertiary';
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'danger';
 }>`
   border: 2px solid transparent;
   padding: 2px;

--- a/frontend/webapp/reuseable-components/drawer/index.tsx
+++ b/frontend/webapp/reuseable-components/drawer/index.tsx
@@ -1,11 +1,12 @@
-import React, { useState, useEffect } from 'react';
-import styled, { css } from 'styled-components';
+import React, { useEffect } from 'react';
+import styled from 'styled-components';
 
 interface DrawerProps {
   isOpen: boolean;
+  width?: string;
   onClose: () => void;
-  position?: 'left' | 'right'; // Optional prop to specify the drawer opening side
-  width?: string; // Optional width control, defaults to 300px
+  closeOnEscape?: boolean;
+  position?: 'left' | 'right';
   children: React.ReactNode;
 }
 
@@ -51,11 +52,14 @@ export const Drawer: React.FC<DrawerProps> = ({
   position = 'right',
   width = '300px',
   children,
+  closeOnEscape = true,
 }) => {
   // Handle closing the drawer when escape key is pressed
   useEffect(() => {
+    if (!closeOnEscape) return;
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === 'Escape' && isOpen) {
+        event.stopPropagation();
         onClose();
       }
     };
@@ -63,7 +67,7 @@ export const Drawer: React.FC<DrawerProps> = ({
     return () => {
       document.removeEventListener('keydown', handleEscape);
     };
-  }, [isOpen, onClose]);
+  }, [isOpen, onClose, closeOnEscape]);
 
   return (
     <>

--- a/frontend/webapp/reuseable-components/modal/index.tsx
+++ b/frontend/webapp/reuseable-components/modal/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Image from 'next/image';
 import { Text } from '../text';
 import ReactDOM from 'react-dom';
@@ -96,6 +96,17 @@ const Modal: React.FC<ModalProps> = ({
   children,
   actionComponent,
 }) => {
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen, onClose]);
   if (!isOpen) return null;
 
   return ReactDOM.createPortal(

--- a/frontend/webapp/reuseable-components/modal/index.tsx
+++ b/frontend/webapp/reuseable-components/modal/index.tsx
@@ -3,11 +3,10 @@ import Image from 'next/image';
 import { Text } from '../text';
 import ReactDOM from 'react-dom';
 import styled from 'styled-components';
-import { Button } from '../button';
 
 interface ModalProps {
   isOpen: boolean;
-  header: {
+  header?: {
     title: string;
   };
   actionComponent?: React.ReactNode;
@@ -102,21 +101,23 @@ const Modal: React.FC<ModalProps> = ({
   return ReactDOM.createPortal(
     <Overlay>
       <ModalWrapper>
-        <ModalHeader>
-          <ModalCloseButton onClick={onClose}>
-            <Image
-              src="/icons/common/x.svg"
-              alt="close"
-              width={15}
-              height={12}
-            />
-            <CancelText>{'Cancel'}</CancelText>
-          </ModalCloseButton>
-          <ModalTitleContainer>
-            <ModalTitle>{header.title}</ModalTitle>
-          </ModalTitleContainer>
-          <HeaderActionsWrapper>{actionComponent}</HeaderActionsWrapper>
-        </ModalHeader>
+        {header && (
+          <ModalHeader>
+            <ModalCloseButton onClick={onClose}>
+              <Image
+                src="/icons/common/x.svg"
+                alt="close"
+                width={15}
+                height={12}
+              />
+              <CancelText>{'Cancel'}</CancelText>
+            </ModalCloseButton>
+            <ModalTitleContainer>
+              <ModalTitle>{header.title}</ModalTitle>
+            </ModalTitleContainer>
+            <HeaderActionsWrapper>{actionComponent}</HeaderActionsWrapper>
+          </ModalHeader>
+        )}
         <ModalContent>{children}</ModalContent>
       </ModalWrapper>
     </Overlay>,

--- a/frontend/webapp/styles/theme.ts
+++ b/frontend/webapp/styles/theme.ts
@@ -14,6 +14,7 @@ const colors = {
   card: '#F9F9F90A',
   dropdown_bg: '#242424',
   blank_background: '#11111100',
+  danger: '#EF7676',
   white_opacity: {
     '004': 'rgba(249, 249, 249, 0.04)',
     '008': 'rgba(249, 249, 249, 0.08)',


### PR DESCRIPTION
This pull request introduces a new `DeleteEntityModal` component and integrates it into the existing `OverviewDrawer` component. It also includes changes to the button component to support a new 'danger' variant, and minor adjustments to the modal and theme files.

### New Component Integration:

* [`frontend/webapp/components/modals/delete-entity-modal/index.tsx`](diffhunk://#diff-a2e2d7cadee95226c9dff027ce7ac63590c2298d33d8755fd30a462842413240R1-R73): Added a new `DeleteEntityModal` component with props for title, description, modal state, and handlers for delete and close actions.
* [`frontend/webapp/containers/main/overview/overview-drawer/index.tsx`](diffhunk://#diff-732721edf7c32d883ffefa52d6e43339c6ee328c88c3cb5f0d87f6760347b599R9): Integrated the `DeleteEntityModal` into the `OverviewDrawer` component, including state management for the modal's visibility and handlers for opening and closing the modal. [[1]](diffhunk://#diff-732721edf7c32d883ffefa52d6e43339c6ee328c88c3cb5f0d87f6760347b599R9) [[2]](diffhunk://#diff-732721edf7c32d883ffefa52d6e43339c6ee328c88c3cb5f0d87f6760347b599R28) [[3]](diffhunk://#diff-732721edf7c32d883ffefa52d6e43339c6ee328c88c3cb5f0d87f6760347b599R100-R104) [[4]](diffhunk://#diff-732721edf7c32d883ffefa52d6e43339c6ee328c88c3cb5f0d87f6760347b599R130-R143)

### Component Exports:

* [`frontend/webapp/components/index.ts`](diffhunk://#diff-9a255ecda06fb13562b464a919eb789a51ea8728251b2aa31c28babfd8f3405dR9): Exported the new `DeleteEntityModal` component.
* [`frontend/webapp/components/modals/index.tsx`](diffhunk://#diff-34b2c64c023a57a6dacb9480d418ea967a16e49dc4e8d874fc6cc8d7addcd001R1): Added export for the `DeleteEntityModal` component.

### Button Component Enhancements:

* [`frontend/webapp/reuseable-components/button/index.tsx`](diffhunk://#diff-8fc0f34e5040f6641ddfafbb1ca5eb7b1a31cb8a3ea36f88a002ab129b23133bL5-R5): Added a 'danger' variant to the button component, including styles for different states (hover, active, focus). [[1]](diffhunk://#diff-8fc0f34e5040f6641ddfafbb1ca5eb7b1a31cb8a3ea36f88a002ab129b23133bL5-R5) [[2]](diffhunk://#diff-8fc0f34e5040f6641ddfafbb1ca5eb7b1a31cb8a3ea36f88a002ab129b23133bL26-R26) [[3]](diffhunk://#diff-8fc0f34e5040f6641ddfafbb1ca5eb7b1a31cb8a3ea36f88a002ab129b23133bR52-R65) [[4]](diffhunk://#diff-8fc0f34e5040f6641ddfafbb1ca5eb7b1a31cb8a3ea36f88a002ab129b23133bR76-R79) [[5]](diffhunk://#diff-8fc0f34e5040f6641ddfafbb1ca5eb7b1a31cb8a3ea36f88a002ab129b23133bL75-R93)

### Minor Adjustments:

* [`frontend/webapp/styles/theme.ts`](diffhunk://#diff-d0707ed65bf1bed4f75f5fbd795a94d2d3abc50b811a78f8e7c010b07d98a32eR17): Added a new color for the 'danger' variant.
* [`frontend/webapp/reuseable-components/modal/index.tsx`](diffhunk://#diff-d4103c71c61595550583187ffac30c3645d1b452db346f20738929a51c954f00L6-R9): Made the modal header optional. [[1]](diffhunk://#diff-d4103c71c61595550583187ffac30c3645d1b452db346f20738929a51c954f00L6-R9) [[2]](diffhunk://#diff-d4103c71c61595550583187ffac30c3645d1b452db346f20738929a51c954f00R104) [[3]](diffhunk://#diff-d4103c71c61595550583187ffac30c3645d1b452db346f20738929a51c954f00R120)
* [`frontend/webapp/containers/main/overview/overview-drawer/drawer-footer/index.tsx`](diffhunk://#diff-99d52f506bacae9503bbf9eec5f6f3411a0b7e9435a0df40137dd39b545c43e7L94-L95): Removed text decoration and transformation from `ButtonText`.