### PR TITLE
feat: integrate auto rule for K8s health probes and refactor upsertLocalUiConfig

### DIFF
--- a/frontend/services/log_level.go
+++ b/frontend/services/log_level.go
@@ -2,73 +2,18 @@ package services
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/common"
-	"github.com/odigos-io/odigos/common/consts"
 	commonlogger "github.com/odigos-io/odigos/common/logger"
-	"github.com/odigos-io/odigos/k8sutils/pkg/env"
-	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/yaml"
 )
 
 func SetComponentLogLevel(ctx context.Context, c client.Client, component string, level common.OdigosLogLevel) error {
-	ns := env.GetCurrentNamespace()
-	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		var cm v1.ConfigMap
-		if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: consts.OdigosLocalUiConfigName}, &cm); err != nil {
-			if apierrors.IsNotFound(err) {
-				// Create odigos-local-ui-config if missing (e.g. first time setting log level from UI).
-				ownerCm := v1.ConfigMap{}
-				if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: consts.OdigosConfigurationName}, &ownerCm); err != nil {
-					return fmt.Errorf("failed to get odigos-configuration for owner reference: %w", err)
-				}
-				cfg := common.OdigosConfiguration{ComponentLogLevels: &common.ComponentLogLevels{}}
-				setComponentLogLevelField(cfg.ComponentLogLevels, component, level)
-				data, marshalErr := yaml.Marshal(cfg)
-				if marshalErr != nil {
-					return marshalErr
-				}
-				newCm := v1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      consts.OdigosLocalUiConfigName,
-						Namespace: ns,
-						Labels:    map[string]string{k8sconsts.OdigosSystemConfigLabelKey: "local-ui"},
-						OwnerReferences: []metav1.OwnerReference{{
-							APIVersion: "v1", Kind: "ConfigMap", Name: ownerCm.Name, UID: ownerCm.UID,
-						}},
-					},
-					Data: map[string]string{consts.OdigosConfigurationFileName: string(data)},
-				}
-				return c.Create(ctx, &newCm)
-			}
-			return err
-		}
-		var cfg common.OdigosConfiguration
-		if cm.Data != nil && cm.Data[consts.OdigosConfigurationFileName] != "" {
-			if err := yaml.Unmarshal([]byte(cm.Data[consts.OdigosConfigurationFileName]), &cfg); err != nil {
-				return fmt.Errorf("parse existing config: %w", err)
-			}
-		}
+	err := upsertLocalUiConfig(ctx, c, func(cfg *common.OdigosConfiguration) {
 		if cfg.ComponentLogLevels == nil {
 			cfg.ComponentLogLevels = &common.ComponentLogLevels{}
 		}
 		setComponentLogLevelField(cfg.ComponentLogLevels, component, level)
-		data, err := yaml.Marshal(cfg)
-		if err != nil {
-			return err
-		}
-		if cm.Data == nil {
-			cm.Data = make(map[string]string)
-		}
-		cm.Data[consts.OdigosConfigurationFileName] = string(data)
-		return c.Update(ctx, &cm)
 	})
 	if err != nil {
 		return err

--- a/frontend/services/odigos_config.go
+++ b/frontend/services/odigos_config.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/odigos-io/odigos/api/k8sconsts"
 	"github.com/odigos-io/odigos/common"
 	"github.com/odigos-io/odigos/common/consts"
 	"github.com/odigos-io/odigos/k8sutils/pkg/env"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,25 +59,62 @@ func GetLocalUIConfig(ctx context.Context, c client.Client) (*common.OdigosConfi
 	return getOdigosConfigFromConfigMap(ctx, c, consts.OdigosLocalUiConfigName)
 }
 
-func PersistUiLocalSamplingConfig(ctx context.Context, c client.Client, samplingConfig *common.SamplingConfiguration) error {
+// upsertLocalUiConfig applies a mutation to the odigos-local-ui-config ConfigMap,
+// creating it with proper owner references if it does not yet exist.
+func upsertLocalUiConfig(ctx context.Context, c client.Client, mutate func(cfg *common.OdigosConfiguration)) error {
 	ns := env.GetCurrentNamespace()
 
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		var cm v1.ConfigMap
-		err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: consts.OdigosLocalUiConfigName}, &cm)
+		if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: consts.OdigosLocalUiConfigName}, &cm); err != nil {
+			if apierrors.IsNotFound(err) {
+				ownerCm := v1.ConfigMap{}
+				if err := c.Get(ctx, types.NamespacedName{Namespace: ns, Name: consts.OdigosConfigurationName}, &ownerCm); err != nil {
+					return fmt.Errorf("failed to get odigos-configuration for owner reference: %w", err)
+				}
+				cfg := common.OdigosConfiguration{}
+				mutate(&cfg)
+				data, marshalErr := yaml.Marshal(cfg)
+				if marshalErr != nil {
+					return marshalErr
+				}
+				newCm := v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      consts.OdigosLocalUiConfigName,
+						Namespace: ns,
+						Labels:    map[string]string{k8sconsts.OdigosSystemConfigLabelKey: "local-ui"},
+						OwnerReferences: []metav1.OwnerReference{{
+							APIVersion: "v1", Kind: "ConfigMap", Name: ownerCm.Name, UID: ownerCm.UID,
+						}},
+					},
+					Data: map[string]string{consts.OdigosConfigurationFileName: string(data)},
+				}
+				return c.Create(ctx, &newCm)
+			}
+			return err
+		}
+
+		var cfg common.OdigosConfiguration
+		if cm.Data != nil && cm.Data[consts.OdigosConfigurationFileName] != "" {
+			if err := yaml.Unmarshal([]byte(cm.Data[consts.OdigosConfigurationFileName]), &cfg); err != nil {
+				return fmt.Errorf("parse existing config: %w", err)
+			}
+		}
+		mutate(&cfg)
+		data, err := yaml.Marshal(cfg)
 		if err != nil {
 			return err
 		}
-		config := common.OdigosConfiguration{}
-		if err := yaml.Unmarshal([]byte(cm.Data[consts.OdigosConfigurationFileName]), &config); err != nil {
-			return err
+		if cm.Data == nil {
+			cm.Data = make(map[string]string)
 		}
-		config.Sampling = samplingConfig
-		yamlText, err := yaml.Marshal(config)
-		if err != nil {
-			return err
-		}
-		cm.Data[consts.OdigosConfigurationFileName] = string(yamlText)
+		cm.Data[consts.OdigosConfigurationFileName] = string(data)
 		return c.Update(ctx, &cm)
+	})
+}
+
+func PersistUiLocalSamplingConfig(ctx context.Context, c client.Client, samplingConfig *common.SamplingConfiguration) error {
+	return upsertLocalUiConfig(ctx, c, func(cfg *common.OdigosConfiguration) {
+		cfg.Sampling = samplingConfig
 	})
 }

--- a/frontend/webapp/app/(v2)/sampling/constants.ts
+++ b/frontend/webapp/app/(v2)/sampling/constants.ts
@@ -11,3 +11,5 @@ export const DELETE_MODAL_TITLE = 'Delete rule?';
 export const DELETE_MODAL_DESCRIPTION = 'Are you sure you want to delete this sampling rule?';
 export const DELETE_MODAL_APPROVE = 'Delete';
 export const DELETE_MODAL_CANCEL = 'Cancel';
+
+export const AUTO_RULE_TITLE = 'Auto rule - Kubernetes Health Probes';

--- a/frontend/webapp/app/(v2)/sampling/page.tsx
+++ b/frontend/webapp/app/(v2)/sampling/page.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 import { FlexColumn, FlexRow, PageContent } from '@odigos/ui-kit/components';
 import { BookIcon, PlusIcon, RefreshIcon, SamplingIcon } from '@odigos/ui-kit/icons';
 import {
-  PageTitle,
+  RichTitle,
   AutoRuleCard,
   buildAutoRuleSummary,
   EditAutoRuleDrawer,
@@ -254,7 +254,7 @@ export default function Page() {
   return (
     <PageContent>
       <Header>
-        <PageTitle icon={SamplingIcon} title={PAGE_TITLE} description={PAGE_DESCRIPTION} />
+        <RichTitle icon={SamplingIcon} title={PAGE_TITLE} subTitle={PAGE_DESCRIPTION} />
 
         <FlexRow $gap={8} $alignItems='center'>
           <Button label={BTN_SAMPLING_DOCS} leftIcon={BookIcon} size={ButtonSize.S} variant={ButtonVariants.Text} onClick={handleDocs} />
@@ -274,6 +274,7 @@ export default function Page() {
         title={SAMPLING_CATEGORY_LIST_TITLES[selectedCategory]}
         items={ruleItems}
         isLoading={loading}
+        showTypeFilter={selectedCategory === SamplingCategory.HighlyRelevant}
         onRuleClick={handleRuleClick}
         onEditRule={handleEditRule}
         onDeleteRule={handleDeleteRule}

--- a/frontend/webapp/app/(v2)/sampling/page.tsx
+++ b/frontend/webapp/app/(v2)/sampling/page.tsx
@@ -9,6 +9,9 @@ import { FlexColumn, FlexRow, PageContent } from '@odigos/ui-kit/components';
 import { BookIcon, PlusIcon, RefreshIcon, SamplingIcon } from '@odigos/ui-kit/icons';
 import {
   PageTitle,
+  AutoRuleCard,
+  buildAutoRuleSummary,
+  EditAutoRuleDrawer,
   SamplingRulesList,
   ViewSamplingRuleDrawer,
   CreateSamplingRuleDrawer,
@@ -29,7 +32,7 @@ import {
   type SamplingRuleFormState,
 } from '@odigos/ui-kit/containers/v2';
 import { StatusType } from '@odigos/ui-kit/types';
-import { DOCS_URL, PAGE_TITLE, PAGE_DESCRIPTION, BTN_SAMPLING_DOCS, BTN_REFRESH, BTN_CREATE_RULE, DELETE_MODAL_TITLE, DELETE_MODAL_DESCRIPTION, DELETE_MODAL_APPROVE, DELETE_MODAL_CANCEL } from './constants';
+import { DOCS_URL, PAGE_TITLE, PAGE_DESCRIPTION, BTN_SAMPLING_DOCS, BTN_REFRESH, BTN_CREATE_RULE, DELETE_MODAL_TITLE, DELETE_MODAL_DESCRIPTION, DELETE_MODAL_APPROVE, DELETE_MODAL_CANCEL, AUTO_RULE_TITLE } from './constants';
 import { Button, ButtonSize, ButtonVariants, Note, Segment, SegmentVariant, WarningModal } from '@odigos/ui-kit/components/v2';
 
 const Header = styled(FlexRow)`
@@ -40,6 +43,7 @@ const Header = styled(FlexRow)`
 export default function Page() {
   const {
     samplingRules,
+    k8sHealthProbesConfig,
     loading,
     fetchSamplingRules,
     createNoisyOperationRule,
@@ -49,6 +53,7 @@ export default function Page() {
     createCostReductionRule,
     updateCostReductionRule,
     deleteSamplingRule,
+    updateK8sHealthProbesConfig,
   } = useSamplingRuleCRUD();
   const { data: workloadsData } = useQuery<{ workloads: { id: { namespace: string; kind: string; name: string } }[] }>(GET_WORKLOADS);
   const [selectedCategory, setSelectedCategory] = useState<SamplingCategory>(SamplingCategory.Noisy);
@@ -56,6 +61,9 @@ export default function Page() {
   const [viewEditMode, setViewEditMode] = useState(false);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<{ ruleId: string; samplingId: string } | null>(null);
+  const [isAutoRuleDrawerOpen, setIsAutoRuleDrawerOpen] = useState(false);
+
+  const autoRuleSummary = useMemo(() => buildAutoRuleSummary(k8sHealthProbesConfig), [k8sHealthProbesConfig]);
 
   const viewRuleRef = useRef(viewRuleData);
   viewRuleRef.current = viewRuleData;
@@ -227,6 +235,22 @@ export default function Page() {
     setDeleteTarget(null);
   }, []);
 
+  const handleEditAutoRule = useCallback(() => {
+    setIsAutoRuleDrawerOpen(true);
+  }, []);
+
+  const handleCloseAutoRuleDrawer = useCallback(() => {
+    setIsAutoRuleDrawerOpen(false);
+  }, []);
+
+  const handleSaveAutoRule = useCallback(
+    (enabled: boolean, keepPercentage: number) => {
+      updateK8sHealthProbesConfig(enabled, keepPercentage);
+      setIsAutoRuleDrawerOpen(false);
+    },
+    [updateK8sHealthProbesConfig],
+  );
+
   return (
     <PageContent>
       <Header>
@@ -243,6 +267,8 @@ export default function Page() {
         <Segment variant={SegmentVariant.Underline} options={SAMPLING_SEGMENT_OPTIONS} selected={selectedCategory} setSelected={setSelectedCategory} />
         <Note status={StatusType.Default} message={SAMPLING_CATEGORY_NOTES[selectedCategory]} />
       </FlexColumn>
+
+      {selectedCategory === SamplingCategory.Noisy && <AutoRuleCard title={AUTO_RULE_TITLE} summary={autoRuleSummary} onEdit={handleEditAutoRule} />}
 
       <SamplingRulesList
         title={SAMPLING_CATEGORY_LIST_TITLES[selectedCategory]}
@@ -265,6 +291,14 @@ export default function Page() {
       />
 
       <CreateSamplingRuleDrawer isOpen={isCreateOpen} category={CATEGORY_TO_RULE_CATEGORY[selectedCategory]} onClose={handleCloseCreateDrawer} onSubmit={handleCreateSubmit} sourceOptions={sourceOptions} namespaceOptions={namespaceOptions} />
+
+      <EditAutoRuleDrawer
+        isOpen={isAutoRuleDrawerOpen}
+        enabled={k8sHealthProbesConfig?.enabled ?? false}
+        keepPercentage={k8sHealthProbesConfig?.keepPercentage ?? 0}
+        onClose={handleCloseAutoRuleDrawer}
+        onSave={handleSaveAutoRule}
+      />
 
       <WarningModal
         title={DELETE_MODAL_TITLE}

--- a/frontend/webapp/graphql/mutations/sampling.ts
+++ b/frontend/webapp/graphql/mutations/sampling.ts
@@ -133,3 +133,11 @@ export const DELETE_COST_REDUCTION_RULE = gql`
     deleteCostReductionRule(samplingId: $samplingId, ruleId: $ruleId)
   }
 `;
+
+// ---- Sampling Config ----
+
+export const UPDATE_LOCAL_UI_SAMPLING_CONFIG = gql`
+  mutation UpdateLocalUiSamplingConfig($config: SamplingConfigInput) {
+    updateLocalUiSamplingConfig(config: $config)
+  }
+`;

--- a/frontend/webapp/graphql/queries/sampling.ts
+++ b/frontend/webapp/graphql/queries/sampling.ts
@@ -53,6 +53,14 @@ const COST_REDUCTION_RULE_FIELDS = `
 export const GET_SAMPLING_RULES = gql`
   query GetSamplingRules {
     sampling {
+      configs {
+        effective {
+          k8sHealthProbesSampling {
+            enabled
+            keepPercentage
+          }
+        }
+      }
       rules {
         id
         name

--- a/frontend/webapp/hooks/sampling/useSamplingRuleCRUD.ts
+++ b/frontend/webapp/hooks/sampling/useSamplingRuleCRUD.ts
@@ -13,20 +13,24 @@ import {
   CREATE_COST_REDUCTION_RULE,
   UPDATE_COST_REDUCTION_RULE,
   DELETE_COST_REDUCTION_RULE,
+  UPDATE_LOCAL_UI_SAMPLING_CONFIG,
 } from '@/graphql/mutations';
 import type {
   SamplingRules,
   SamplingRuleType,
+  SamplingQueryResponse,
   NoisyOperationRule,
   NoisyOperationRuleInput,
   HighlyRelevantOperationRule,
   HighlyRelevantOperationRuleInput,
   CostReductionRule,
   CostReductionRuleInput,
+  K8sHealthProbesSamplingConfig,
 } from '@/types';
 
 interface UseSamplingRuleCrud {
   samplingRules: SamplingRules[];
+  k8sHealthProbesConfig: K8sHealthProbesSamplingConfig | null;
   loading: boolean;
   fetchSamplingRules: () => void;
 
@@ -40,6 +44,8 @@ interface UseSamplingRuleCrud {
   updateCostReductionRule: (samplingId: string, ruleId: string, rule: CostReductionRuleInput) => void;
 
   deleteSamplingRule: (samplingId: string, ruleId: string, category: SamplingRuleType) => void;
+
+  updateK8sHealthProbesConfig: (enabled: boolean, keepPercentage: number) => void;
 }
 
 function updateGroup(groups: SamplingRules[], samplingId: string, updater: (group: SamplingRules) => SamplingRules): SamplingRules[] {
@@ -55,6 +61,7 @@ function updateGroup(groups: SamplingRules[], samplingId: string, updater: (grou
 export const useSamplingRuleCRUD = (): UseSamplingRuleCrud => {
   const { addNotification } = useNotificationStore();
   const [samplingRules, setSamplingRules] = useState<SamplingRules[]>([]);
+  const [k8sHealthProbesConfig, setK8sHealthProbesConfig] = useState<K8sHealthProbesSamplingConfig | null>(null);
   const [loading, setLoading] = useState(false);
 
   const notifyUser = useCallback(
@@ -66,7 +73,7 @@ export const useSamplingRuleCRUD = (): UseSamplingRuleCrud => {
 
   // ---- Fetch ----
 
-  const [fetchAll] = useLazyQuery<{ sampling: { rules: SamplingRules[] } }>(GET_SAMPLING_RULES, { fetchPolicy: 'network-only' });
+  const [fetchAll] = useLazyQuery<SamplingQueryResponse>(GET_SAMPLING_RULES, { fetchPolicy: 'network-only' });
 
   const fetchSamplingRules = useCallback(async () => {
     setLoading(true);
@@ -74,8 +81,9 @@ export const useSamplingRuleCRUD = (): UseSamplingRuleCrud => {
 
     if (error) {
       notifyUser(StatusType.Error, Crud.Read, error.cause?.message || error.message);
-    } else if (data?.sampling?.rules) {
+    } else if (data?.sampling) {
       setSamplingRules(data.sampling.rules);
+      setK8sHealthProbesConfig(data.sampling.configs?.effective?.k8sHealthProbesSampling ?? null);
     }
     setLoading(false);
   }, [fetchAll, notifyUser]);
@@ -221,6 +229,22 @@ export const useSamplingRuleCRUD = (): UseSamplingRuleCrud => {
     },
   });
 
+  // ---- Sampling Config ----
+
+  const [mutateUpdateConfig] = useMutation<{ updateLocalUiSamplingConfig: boolean }, { config: { k8sHealthProbesSampling: { enabled: boolean; keepPercentage: number } } }>(
+    UPDATE_LOCAL_UI_SAMPLING_CONFIG,
+    {
+      onError: (error) => notifyUser(StatusType.Error, Crud.Update, error.cause?.message || error.message),
+      onCompleted: (_res, opts) => {
+        const input = opts?.variables?.config.k8sHealthProbesSampling;
+        if (input) {
+          setK8sHealthProbesConfig({ enabled: input.enabled, keepPercentage: input.keepPercentage });
+        }
+        notifyUser(StatusType.Success, Crud.Update, 'Successfully updated auto rule configuration');
+      },
+    },
+  );
+
   // ---- Public API ----
 
   const createNoisyOperationRule: UseSamplingRuleCrud['createNoisyOperationRule'] = (samplingId, rule) => {
@@ -261,12 +285,17 @@ export const useSamplingRuleCRUD = (): UseSamplingRuleCrud => {
     }
   };
 
+  const updateK8sHealthProbesConfig: UseSamplingRuleCrud['updateK8sHealthProbesConfig'] = (enabled, keepPercentage) => {
+    mutateUpdateConfig({ variables: { config: { k8sHealthProbesSampling: { enabled, keepPercentage } } } });
+  };
+
   useEffect(() => {
     fetchSamplingRules();
   }, []);
 
   return {
     samplingRules,
+    k8sHealthProbesConfig,
     loading,
     fetchSamplingRules,
     createNoisyOperationRule,
@@ -276,5 +305,6 @@ export const useSamplingRuleCRUD = (): UseSamplingRuleCrud => {
     createCostReductionRule,
     updateCostReductionRule,
     deleteSamplingRule,
+    updateK8sHealthProbesConfig,
   };
 };

--- a/frontend/webapp/types/sampling.ts
+++ b/frontend/webapp/types/sampling.ts
@@ -118,3 +118,19 @@ export interface CostReductionRuleInput {
   percentageAtMost: number;
   notes?: string | null;
 }
+
+export interface K8sHealthProbesSamplingConfig {
+  enabled: boolean | null;
+  keepPercentage: number | null;
+}
+
+export interface SamplingQueryResponse {
+  sampling: {
+    configs: {
+      effective: {
+        k8sHealthProbesSampling: K8sHealthProbesSamplingConfig | null;
+      };
+    };
+    rules: SamplingRules[];
+  };
+}


### PR DESCRIPTION
Integrate the K8s health probes auto rule into the sampling page and consolidate duplicated ConfigMap upsert logic in the backend.

```release-note
NONE
```